### PR TITLE
Fixed return statement to work with v3 console

### DIFF
--- a/payload_formatter_v3.js
+++ b/payload_formatter_v3.js
@@ -33,5 +33,5 @@ function decodeUplink(input) {
         ptr = ptr + 9;
     }
 
-    return data;
+    return { data } ;
 }


### PR DESCRIPTION
I think you missed an addtional pair of  { } to return the JSON message in the correct way.